### PR TITLE
Fix mergeAddress test

### DIFF
--- a/modules/addons/caasify/basics/vendor/persgeek/request/tests/RequestTest.php
+++ b/modules/addons/caasify/basics/vendor/persgeek/request/tests/RequestTest.php
@@ -18,9 +18,9 @@ class RequestTest extends TestCase
     {
         $request = new Request();
 
-        $request->setAddress(['test/test']);
+        $request->setAddress(['api', 'v1', 'test']);
 
-        $this->assertSame('test/test', $request->mergeAddress());
+        $this->assertSame('api/v1/test', $request->mergeAddress());
     }
 
     public function testHeaders()


### PR DESCRIPTION
## Summary
- update RequestTest to verify mergeAddress with multiple segments

## Testing
- `/usr/bin/phpunit -c modules/addons/caasify/basics/vendor/persgeek/request/phpunit.xml --bootstrap /tmp/bootstrap.php`

------
https://chatgpt.com/codex/tasks/task_b_686e8d0fdb00832a8d00048d9ba99b4d