### PR TITLE
Fix config variable and validation logic

### DIFF
--- a/modules/addons/caasify/ClientCaasifyController.php
+++ b/modules/addons/caasify/ClientCaasifyController.php
@@ -563,7 +563,7 @@ class ClientCaasifyController
 
         $WhUserId = $this->WhUserId;
 
-        if(empty($Ratio) || empty($Chargeamount) || empty($WhUserId) | empty($CaasifyUserId)){
+        if(empty($Ratio) || empty($Chargeamount) || empty($WhUserId) || empty($CaasifyUserId)){
             $message = 'ratio, or amount, or user id is not defined';
             $this->response($message);
             return false;
@@ -682,7 +682,7 @@ class ClientCaasifyController
         }
 
         $WhUserId = $this->WhUserId;
-        if(empty($Ratio) || empty($Chargeamount) || empty($WhUserId) | empty($CaasifyUserId)){
+        if(empty($Ratio) || empty($Chargeamount) || empty($WhUserId) || empty($CaasifyUserId)){
             $message = 'ratio, or amount, or user id is not defined';
             $this->response($message);
             return false;

--- a/modules/addons/caasify/caasify.php
+++ b/modules/addons/caasify/caasify.php
@@ -263,8 +263,8 @@ function caasify_clientarea($vars){
         return false;
     }
 
-    $configs = caasify_get_config_decoded();
-    $BackendUrl = $configs['BackendUrl'];
+    $config = caasify_get_config_decoded();
+    $BackendUrl = $config['BackendUrl'];
     if(empty($BackendUrl)){
         echo 'can not find BackendUrl to construct controller <br>';
         return false;


### PR DESCRIPTION
## Summary
- fix incorrect variable name in `caasify_clientarea`
- use logical OR in charge creation checks

## Testing
- `php -l modules/addons/caasify/ClientCaasifyController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686e7f4cd1d0832aad28ff5c70932c00